### PR TITLE
split go report card from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Go
+name: Build
 
 on:
   push:
@@ -28,6 +28,4 @@ jobs:
 
     - name: Build
       run: go build -v .
-    
-    - name: Go report card
-      uses: creekorful/goreportcard-action@v1.0
+

--- a/.github/workflows/goreportcard.yml
+++ b/.github/workflows/goreportcard.yml
@@ -1,0 +1,15 @@
+name: Go Report Card
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+
+  reportcard:
+    name: Go Report Card
+    runs-on: ubuntu-latest
+    steps:
+    
+    - name: Go report card
+      uses: creekorful/goreportcard-action@v1.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # QR Code API
+![build](https://github.com/codebender/qrcode-api/workflows/Build/badge.svg?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/codebender/qrcode-api)](https://goreportcard.com/report/github.com/codebender/qrcode-api)
 
 Go-Kit gRPC service that returns a QR code image


### PR DESCRIPTION
- only update report card when new code is pushed to the mast branch
- add Build badge to readme